### PR TITLE
homepage date fix 2017 -> 2016

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ hide_header_logo: "true"
       </div>
 
       <div class="status">
-        <strong>Update July 2017</strong>: Read about <a href="https://kenneth.io/blog/2016/07/05/introducing-remotedebug-compatibility-tables/">Introducing RemoteDebug Compatibility Tables for remote debugging protocols and APIs</a>
+        <strong>Update July 2016</strong>: Read about <a href="https://kenneth.io/blog/2016/07/05/introducing-remotedebug-compatibility-tables/">Introducing RemoteDebug Compatibility Tables for remote debugging protocols and APIs</a>
         <strong>Update</strong>: Read about <a href="https://kenneth.io/blog/2015/03/12/remotedebug-one-year-later/">RemoteDebug and cross-browser DevTools. One year later.</a>
       </div>
     </div>


### PR DESCRIPTION
The blogpost is from 2016, not 2017