### PR TITLE
add remotedebug-ios-webkit-adapter to adapters

### DIFF
--- a/adaptors/index.html
+++ b/adaptors/index.html
@@ -24,7 +24,17 @@ layout: default
       </div>
       <div class="bd">
         <h3><a href="https://github.com/google/ios-webkit-debug-proxy">iOS Webkit Debug Proxy</a></h3>
-        <p>Protocol adaptor for Apple Safari (iOS devices).</p>
+        <p>Protocol proxy for Mobile Safari (iOS &amp; Simulator).</p>
+      </div>
+    </li>
+    
+    <li class="webkit media">
+      <div class="img">
+        <img src="/images/webkit.png" />
+      </div>
+      <div class="bd">
+        <h3><a href="https://github.com/RemoteDebug/remotedebug-ios-webkit-adapter">RemoteDebug iOS WebKit Adapter</a></h3>
+        <p>Protocol adaptor for Apple Safari and WebKit.</p>
       </div>
     </li>
 


### PR DESCRIPTION
same icon because lazy, but i could see it making sense having the proxy use the safari icon instead.

![image](https://cloud.githubusercontent.com/assets/39191/23297597/fc596b6e-fa2e-11e6-9cfa-1c5cb9a515ed.png)
